### PR TITLE
Download correct linaro toolchain for host machine

### DIFF
--- a/tools/install_linaro.sh
+++ b/tools/install_linaro.sh
@@ -34,7 +34,7 @@ if [ x$OS == "xWindows_NT" ]
 then
 	GCCFILE=gcc-linaro-7.5.0-2019.12-i686-mingw32_arm-eabi
 else
-	GCCFILE=gcc-linaro-7.5.0-2019.12-i686_arm-eabi
+	GCCFILE=gcc-linaro-7.5.0-2019.12-$(uname -m)_arm-eabi
 fi
 
 if [ -f ${GCCFILE}.tar.xz ]


### PR DESCRIPTION
This updates the `install_linaro.sh` script to change the installed tar based on the linux host architecture, windows mingw behavior is unchanged.

`uname -m` will return the correct machine identifier in the target triple, and correctly change the artifact to download from the linaro binary releases [here](https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/arm-eabi/)